### PR TITLE
tab titles, re-ordering, collapse/expand

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "MP Tweaks!",
-	"version": "2.44",
+	"version": "2.45",
 	"manifest_version": 3,
 	"description": "this is an extension (by AK) to add feature flags to Mixpanel",
 	"homepage_url": "https://mixpanel.com",

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@
 // @ts-ignore
 let STORAGE;
 
-const APP_VERSION = `2.43`;
+const APP_VERSION = `2.45`;
 // const FEATURE_FLAG_URI = `https://docs.google.com/spreadsheets/d/e/2PACX-1vTks7GMkQBfvqKgjIyzLkRYAGRhcN6yZhI46lutP8G8OokZlpBO6KxclQXGINgS63uOmhreG9ClnFpb/pub?gid=0&single=true&output=csv`;
 // const DEMO_GROUPS_URI = `https://docs.google.com/spreadsheets/d/e/2PACX-1vQdxs7SWlOc3f_b2f2j4fBk2hwoU7GBABAmJhtutEdPvqIU4I9_QRG6m3KSWNDnw5CYB4pEeRAiSjN7/pub?gid=0&single=true&output=csv`;
 // const TOOLS_URI = `https://docs.google.com/spreadsheets/d/e/2PACX-1vRN5Eu0Lj2dfxM7OSZiR91rcN4JSTprUz07wk8jZZyxOhOHZvRnlgGHJKIOHb6DIb4sjQQma35dCzPZ/pub?gid=0&single=true&output=csv`;
@@ -1447,23 +1447,8 @@ function initCollapsibleSections() {
 function setupCollapsibleSections() {
 	// Get current storage from APP
 	APP.getStorage().then(storage => {
-		// Initialize sectionStates if it doesn't exist (for existing users)
-		if (!storage.sectionStates) {
-			storage.sectionStates = {
-				modHeader: { expanded: true },
-				demoLinks: { expanded: true },
-				dataTools: { expanded: true },
-				createProject: { expanded: true },
-				sessionReplay: { expanded: true },
-				dataEditor: { expanded: true },
-				perTab: { expanded: true },
-				persistentOptions: { expanded: true },
-				oddsEnds: { expanded: true }
-			};
-			APP.setStorage(storage);
-		}
-
-		// Set initial states for all sections
+		// Set initial states for all sections based on saved preferences
+		// Do NOT initialize defaults here - the worker handles that
 		document.querySelectorAll('.section[id]').forEach(section => {
 			const sectionName = section.id;
 			const toggle = section.querySelector('.collapse-toggle');
@@ -1508,19 +1493,10 @@ function toggleSection(sectionName) {
 
 	// Update storage
 	APP.getStorage().then(storage => {
-		// Initialize sectionStates if it doesn't exist
+		// Ensure sectionStates exists (should always exist from worker init)
 		if (!storage.sectionStates) {
-			storage.sectionStates = {
-				modHeader: { expanded: true },
-				demoLinks: { expanded: true },
-				dataTools: { expanded: true },
-				createProject: { expanded: true },
-				sessionReplay: { expanded: true },
-				dataEditor: { expanded: true },
-				perTab: { expanded: true },
-				persistentOptions: { expanded: true },
-				oddsEnds: { expanded: true }
-			};
+			console.warn('mp-tweaks: sectionStates missing, creating minimal entry');
+			storage.sectionStates = {};
 		}
 
 		storage.sectionStates[sectionName] = { expanded: isCurrentlyCollapsed };

--- a/src/styles.css
+++ b/src/styles.css
@@ -182,6 +182,41 @@ p {
   opacity: 0;
 }
 
+/* Drag and drop styles */
+.drag-handle {
+  cursor: grab;
+  color: var(--text-muted);
+  font-size: 16px;
+  padding: 0 4px;
+  user-select: none;
+  opacity: 0.4;
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+
+.drag-handle:hover {
+  opacity: 1;
+  color: var(--accent-purple);
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.section.dragging {
+  opacity: 0.5;
+  transform: scale(0.98);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.section.drag-over {
+  border-top: 2px solid var(--accent-purple);
+  margin-top: 2px;
+}
+
+.section.drag-over-bottom {
+  border-bottom: 2px solid var(--accent-purple);
+  margin-bottom: 2px;
+}
 
 .section h2.lower {
   margin-top: 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,44 +1,52 @@
 export type ChromeStorage = {
-	version: string;
-	persistScripts: string[];
-	serviceAcct: {
-	  user: string;
-	  pass: string;
-	};
-	whoami: {
-	  name: string;
-	  email: string;
-	  orgId: string;
-	  oauthToken: string;
-	  orgName: string;
-	};
-	// featureFlags: Object[];
-	// demoLinks: Object[];
-	sessionReplay: {
-	  token: string;
-	  enabled: boolean;
-	  tabId: number;
-	};
-	verbose: boolean;
-	last_updated?: number;
-	modHeaders: {
-		headers: ModHeaders[]
-		enabled: boolean;
-	}
-	responseOverrides: {
-		/** projectId : list of overrides */
-		[key: number]: Object[]
-	}	
+  version: string;
+  persistScripts: string[];
+  serviceAcct: {
+    user: string;
+    pass: string;
   };
-  
+  whoami: {
+    name: string;
+    email: string;
+    orgId: string;
+    oauthToken: string;
+    orgName: string;
+  };
+  // featureFlags: Object[];
+  // demoLinks: Object[];
+  sessionReplay: {
+    token: string;
+    enabled: boolean;
+    tabId: number;
+  };
+  verbose: boolean;
+  last_updated?: number;
+  modHeaders: {
+    headers: ModHeaders[];
+    enabled: boolean;
+    savedHeaders: ModHeaders[];
+  };
+  responseOverrides: {
+    /** projectId : list of overrides */
+    [key: number]: Object[];
+  };
+  externalDataCache: {
+	[key: string]: any;
+  };
+  sectionStates: {
+	[key: string]: any;
+  };
+  sectionOrder: string[];
+};
+
 // Define a type for the additional string key-value pairs
 type AdditionalHeaders = {
-    [key: string]: string;
-}
+  [key: string]: string;
+};
 
 // Define a type that includes the specific 'enabled' property and additional properties
 type ModHeaders = AdditionalHeaders & {
-    enabled: boolean;
-}
+  enabled: boolean;
+};
 
-type Hacks = '100x' | 'hideBanners' | 'renameTabs' | 'hideBetas'
+type Hacks = "100x" | "hideBanners" | "renameTabs" | "hideBetas";

--- a/src/worker.js
+++ b/src/worker.js
@@ -64,7 +64,7 @@ function cleanupAllTimers() {
 	activeTimeouts.clear();
 }
 
-const APP_VERSION = `2.44`;
+const APP_VERSION = `2.45`;
 const SCRIPTS = {
 	"hundredX": { path: './src/tweaks/hundredX.js', code: "" },
 	"catchFetch": { path: "./src/tweaks/catchFetch.js", code: "" },

--- a/src/worker.js
+++ b/src/worker.js
@@ -101,6 +101,7 @@ const STORAGE_MODEL = {
 		persistentOptions: { expanded: true },
 		oddsEnds: { expanded: true }
 	},
+	sectionOrder: ['modHeader', 'demoLinks', 'dataTools', 'createProject', 'sessionReplay', 'dataEditor', 'perTab', 'persistentOptions', 'oddsEnds']
 };
 
 /*
@@ -133,6 +134,7 @@ async function init() {
 			persistentOptions: { expanded: true },
 			oddsEnds: { expanded: true }
 		},
+		sectionOrder: raw.sectionOrder || ['modHeader', 'demoLinks', 'dataTools', 'createProject', 'sessionReplay', 'dataEditor', 'perTab', 'persistentOptions', 'oddsEnds'],
 		externalDataCache: raw.externalDataCache || {
 			featureFlags: { data: [], timestamp: 0 },
 			demoLinks: { data: [], timestamp: 0 },
@@ -335,7 +337,7 @@ async function handleRequest(request) {
 	let result = null;
 	const catchFetchUri = chrome.runtime.getURL('/src/tweaks/catchFetch.js');
 	const reqId = uid();
-	track('worker start', { action: request.action, data: request.data, reqId });
+	//track('worker start', { action: request.action, data: request.data, reqId });
 
 	switch (request.action) {
 		case 'refresh-storage':
@@ -861,12 +863,69 @@ async function injectToolTip(tooltip) {
 		});
 	}
 
-	if (typeof tooltip === 'string') tooltip = { primary: tooltip };
+	if (typeof tooltip === 'string') tooltip = { title: tooltip }; //title is the default and should replace the document.title
 	if (typeof tooltip !== 'object') throw new Error('Invalid tooltip data');
 	if (!tooltip.primary) tooltip.primary = "";
 	if (!tooltip.secondary) tooltip.secondary = "";
+	if (!tooltip.title) tooltip.title = "";
 	if (tooltip.text && !tooltip.secondary) tooltip.primary = tooltip.text;
 	if (tooltip.tooltip && !tooltip.secondary && !tooltip.primary) tooltip.primary = tooltip.tooltip;
+
+	// Handle custom tab title immediately if provided
+	if (tooltip.title && tooltip.title.trim() !== "") {
+		const customTitle = tooltip.title.trim();
+		console.log('mp-tweaks: setting custom tab title:', customTitle);
+
+		// Set title immediately
+		document.title = customTitle;
+
+		// Protect against other code changing the title
+		// Store the desired title
+		window.__mpTweaksCustomTitle = customTitle;
+
+		// Watch for title changes and reset if needed
+		const titleObserver = new MutationObserver(() => {
+			if (document.title !== window.__mpTweaksCustomTitle) {
+				console.log('mp-tweaks: resetting tab title to:', window.__mpTweaksCustomTitle);
+				document.title = window.__mpTweaksCustomTitle;
+			}
+		});
+
+		// Observe title element changes
+		const titleElement = document.querySelector('title');
+		if (titleElement) {
+			titleObserver.observe(titleElement, {
+				childList: true,
+				characterData: true,
+				subtree: true
+			});
+		}
+
+		// Also use Object.defineProperty for extra protection
+		try {
+			Object.defineProperty(document, 'title', {
+				get: function() {
+					return window.__mpTweaksCustomTitle || document.querySelector('title')?.textContent || '';
+				},
+				set: function(newTitle) {
+					// Only allow setting if it matches our custom title
+					if (newTitle === window.__mpTweaksCustomTitle || !window.__mpTweaksCustomTitle) {
+						const titleEl = document.querySelector('title');
+						if (titleEl) {
+							titleEl.textContent = newTitle;
+						}
+					} else {
+						console.log('mp-tweaks: blocked title change attempt to:', newTitle);
+					}
+				},
+				configurable: true
+			});
+		} catch (e) {
+			// Some browsers may not allow redefining document.title
+			console.warn('mp-tweaks: could not protect title with defineProperty:', e);
+		}
+	}
+
 	if (!tooltip.primary && !tooltip.secondary) return; // no text to inject
 
 	const html = `
@@ -936,7 +995,6 @@ async function nukeCookies(domain = "mixpanel.com") {
 	}
 	return cookies.length;
 }
-
 
 async function runScript(funcOrPath, args = [], opts, target) {
 	try {


### PR DESCRIPTION
version 2.45 lets to move your "tools" around and collapse/expand them for a custom view.

it also puts a `titles` prop in the `metadata` which gets re-written as the `document.title` for better demo sequences 


<img width="505" height="356" alt="SCR-20251005-tmzf" src="https://github.com/user-attachments/assets/d7771e03-71f1-4817-93c4-1d7f83c04274" />
